### PR TITLE
Removed dependency on specific matplotlib version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,15 +14,31 @@ channels:
   - conda-forge
   - defaults
 
+# List all explicitly imported/used packages
+# ------------------------------------------
+#
+# Example -- Consider a Python file with following imports:
+#
+#   import package_A
+#   import package_B
+#
+# Assume:
+#
+# ==> 'package_A' depends on 'package_B'
+# ==> 'package_B' depends on a third 'package_C'
+#
+# 'package_A' and 'package_B' should be listed in this file since they
+# are explicitly imported, but we do not list 'package_C'.
+
 dependencies:
   - python>=3.6
 
   # Required
   - numpy>=1.15
   - cpacscreator>=0.1
-  #- tigl3>=3.0.0rc  # Should be included in cpacscreator
+  - tigl3>=3.0.0
   - tixi3>=3.0.3
-  - matplotlib==3.0.2
+  - matplotlib>=3.0.2
   - scipy>=1.1
   - scikit-learn>=0.21.3
   - pandas>=0.25.0

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   # Required
   - numpy>=1.15
   - cpacscreator>=0.1
-  - tigl3>=3.0.0
+  #- tigl3>=3.0.0rc  # Should be included in cpacscreator
   - tixi3>=3.0.3
   - matplotlib>=3.0.2
   - scipy>=1.1


### PR DESCRIPTION
We forced the use of matplotlib version 3.0.2 because newer versions of
matplotlib would raise a 'NotImplementedError' if a set_aspect('equal')
method was called.

There is no module which relies on said specific version anymore. We can therefore
relax the requirement. More on the set_aspect() issue in matplotlib:

matplotlib issue 1077

I also added 'tigl3' as an explicit dependency (again). I think all
packages which are explicitly imported/used should be listed in
``environment.yml``, otherwise it becomes hard to track what is required
and what is not. See also the note I made in the ``environment.yml`` file.
Feel free to comment on this, if you disagree :)