### PR TITLE
Upgrade to gmsh 4.10.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - pip:
     - smt==0.7.1
     - cpacspy==0.0.8
-    - gmsh >= 4.9.5
+    - gmsh >= 4.10.1
     #- aeroframe  # See: https://github.com/airinnova/aeroframe
     #- framat  # See: https://github.com/airinnova/framat
     # - mpi4py # issue at installation of environment


### PR DESCRIPTION
Upgrade to gmsh version 4.10.1, more info on the 4.10 release: https://gitlab.onelab.info/gmsh/gmsh/-/releases/gmsh_4_10_0
This new version seems stable by successfully passing all the pytest and a simple workflow.