### PR TITLE
Update cpacspy to version 0.0.11

### DIFF
--- a/ceasiompy/CLCalculator/clcalculator.py
+++ b/ceasiompy/CLCalculator/clcalculator.py
@@ -104,7 +104,7 @@ def get_cl(cpacs_path, cpacs_out_path):
         cpacs_out_path (Path): Path to CPACS output file
     """
 
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
     tixi = cpacs.tixi
 
     # XPath definition
@@ -160,7 +160,7 @@ def get_cl(cpacs_path, cpacs_out_path):
     tixi.updateTextElement(SU2_FIXED_CL_XPATH, "YES")
     log.info("Target CL has been saved in the CPACS file")
 
-    cpacs.save_cpacs(str(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path, overwrite=True)
 
 
 # =================================================================================================

--- a/ceasiompy/CLCalculator/tests/test_clcalculator.py
+++ b/ceasiompy/CLCalculator/tests/test_clcalculator.py
@@ -54,7 +54,7 @@ def test_calculate_cl():
 def test_get_cl():
     """Test function 'get_cl'"""
 
-    get_cl(str(CPACS_IN_PATH), str(CPACS_OUT_PATH))
+    get_cl(CPACS_IN_PATH, CPACS_OUT_PATH)
 
     tixi = open_tixi(str(CPACS_OUT_PATH))
 

--- a/ceasiompy/CLCalculator/tests/test_clcalculator.py
+++ b/ceasiompy/CLCalculator/tests/test_clcalculator.py
@@ -56,7 +56,7 @@ def test_get_cl():
 
     get_cl(CPACS_IN_PATH, CPACS_OUT_PATH)
 
-    tixi = open_tixi(str(CPACS_OUT_PATH))
+    tixi = open_tixi(CPACS_OUT_PATH)
 
     cl_to_check = tixi.getDoubleElement(SU2_TARGET_CL_XPATH)
     assert cl_to_check == approx(0.791955)

--- a/ceasiompy/CPACS2GMSH/cpacs2gmsh.py
+++ b/ceasiompy/CPACS2GMSH/cpacs2gmsh.py
@@ -52,7 +52,7 @@ MODULE_NAME = MODULE_DIR.name
 def cpacs2gmsh(cpacs_path, cpacs_out_path):
 
     # Get option from the CPACS file
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
 
     # Create results directory
     results_dir = get_results_directory("CPACS2GMSH")
@@ -102,7 +102,7 @@ def cpacs2gmsh(cpacs_path, cpacs_out_path):
         log.info("SU2 Mesh has been correctly generated.")
 
     # Save CPACS
-    cpacs.save_cpacs(str(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path, overwrite=True)
 
 
 # =================================================================================================

--- a/ceasiompy/CPACS2GMSH/tests/test_advancemeshing.py
+++ b/ceasiompy/CPACS2GMSH/tests/test_advancemeshing.py
@@ -222,7 +222,7 @@ def test_refine_wing_section():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_IN_PATH))
+    cpacs = CPACS(CPACS_IN_PATH)
 
     export_brep(cpacs, TEST_OUT_PATH)
 
@@ -288,7 +288,7 @@ def test_check_mesh():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_IN_PATH))
+    cpacs = CPACS(CPACS_IN_PATH)
 
     export_brep(cpacs, TEST_OUT_PATH)
 

--- a/ceasiompy/CPACS2GMSH/tests/test_exportbrep.py
+++ b/ceasiompy/CPACS2GMSH/tests/test_exportbrep.py
@@ -46,7 +46,7 @@ def test_export_brep():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_IN_PATH))
+    cpacs = CPACS(CPACS_IN_PATH)
 
     export_brep(cpacs, TEST_OUT_PATH)
 

--- a/ceasiompy/CPACS2GMSH/tests/test_generatemesh.py
+++ b/ceasiompy/CPACS2GMSH/tests/test_generatemesh.py
@@ -60,7 +60,7 @@ def test_generate_gmsh():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_IN_PATH))
+    cpacs = CPACS(CPACS_IN_PATH)
 
     export_brep(cpacs, TEST_OUT_PATH)
 
@@ -108,7 +108,7 @@ def test_generate_gmsh_symm():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_IN_PATH))
+    cpacs = CPACS(CPACS_IN_PATH)
 
     export_brep(cpacs, TEST_OUT_PATH)
 
@@ -154,7 +154,7 @@ def test_symm_part_removed():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_IN_PATH))
+    cpacs = CPACS(CPACS_IN_PATH)
 
     export_brep(cpacs, TEST_OUT_PATH)
 
@@ -288,7 +288,7 @@ def test_assignation():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_IN_PATH))
+    cpacs = CPACS(CPACS_IN_PATH)
 
     export_brep(cpacs, TEST_OUT_PATH)
 

--- a/ceasiompy/CPACS2GMSH/tests/test_wingclassification.py
+++ b/ceasiompy/CPACS2GMSH/tests/test_wingclassification.py
@@ -229,7 +229,7 @@ def test_classify_wing():
         shutil.rmtree(TEST_OUT_PATH)
     TEST_OUT_PATH.mkdir()
 
-    cpacs = CPACS(str(CPACS_SIMPLE))
+    cpacs = CPACS(CPACS_SIMPLE)
 
     export_brep(cpacs, TEST_OUT_PATH)
 

--- a/ceasiompy/CPACS2SUMO/cpacs2sumo.py
+++ b/ceasiompy/CPACS2SUMO/cpacs2sumo.py
@@ -14,10 +14,10 @@ TODO:
 
     * Write some documentation and tutorial
     * Improve testing script
-    * Use <segements> both for wing and fuselage, as they define which
+    * Use <segments> both for wing and fuselage, as they define which
       part of the fuselage/wing should be built
     * Use 'sumo_str_format' function everywhere
-    * Impove the class data structure of Engine
+    * Improve the class data structure of Engine
     * Use class data structure for fuselage and wings
 """
 
@@ -40,16 +40,18 @@ from ceasiompy.CPACS2SUMO.func.sumofunctions import (
 )
 from ceasiompy.utils.ceasiomlogger import get_logger
 from ceasiompy.utils.ceasiompyutils import get_results_directory
-from ceasiompy.utils.generalclasses import SimpleNamespace, Transformation
-from ceasiompy.utils.mathfunctions import euler2fix
-from ceasiompy.utils.moduleinterfaces import get_toolinput_file_path, get_tooloutput_file_path
 from ceasiompy.utils.commonxpath import (
     ENGINES_XPATH,
     FUSELAGES_XPATH,
     PYLONS_XPATH,
+    SUMO_INCLUDE_ENGINE_XPATH,
+    SUMO_INCLUDE_PYLON_XPATH,
     SUMOFILE_XPATH,
     WINGS_XPATH,
 )
+from ceasiompy.utils.generalclasses import SimpleNamespace, Transformation
+from ceasiompy.utils.mathfunctions import euler2fix
+from ceasiompy.utils.moduleinterfaces import get_toolinput_file_path, get_tooloutput_file_path
 from cpacspy.cpacsfunctions import create_branch, get_value_or_default, open_tixi
 
 log = get_logger()
@@ -89,12 +91,10 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
 
     """
 
-    EMPTY_SMX = Path(MODULE_DIR, "files", "sumo_empty.smx")
-
     tixi = open_tixi(cpacs_path)
-    sumo = open_tixi(EMPTY_SMX)
+    sumo = open_tixi(Path(MODULE_DIR, "files", "sumo_empty.smx"))
 
-    # Fuslage(s) ---------------------------------------------------------------
+    # Fuselage(s) ---------------------------------------------------------------
 
     if tixi.checkElement(FUSELAGES_XPATH):
         fus_cnt = tixi.getNamedChildrenCount(FUSELAGES_XPATH, "fuselage")
@@ -145,7 +145,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
         # Positionings
         if tixi.checkElement(fus_xpath + "/positionings"):
             pos_cnt = tixi.getNamedChildrenCount(fus_xpath + "/positionings", "positioning")
-            log.info(str(fus_cnt) + ' "Positionning" has been found : ')
+            log.info(str(fus_cnt) + ' "Positioning" has been found : ')
 
             pos_x_list = []
             pos_y_list = []
@@ -162,12 +162,12 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
                 dihedral_deg = tixi.getDoubleElement(pos_xpath + "/dihedralAngle")
                 dihedral = math.radians(dihedral_deg)
 
-                # Get the corresponding translation of each positionning
+                # Get the corresponding translation of each positioning
                 pos_x_list.append(length * math.sin(sweep))
                 pos_y_list.append(length * math.cos(dihedral) * math.cos(sweep))
                 pos_z_list.append(length * math.sin(dihedral) * math.cos(sweep))
 
-                # Get which section are connected by the positionning
+                # Get which section are connected by the positioning
                 if tixi.checkElement(pos_xpath + "/fromSectionUID"):
                     from_sec = tixi.getTextElement(pos_xpath + "/fromSectionUID")
                 else:
@@ -180,7 +180,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
                     to_sec = ""
                 to_sec_list.append(to_sec)
 
-            # Re-loop though the positionning to re-order them
+            # Re-loop though the positioning to re-order them
             for j_pos in range(pos_cnt):
                 if from_sec_list[j_pos] == "":
                     prev_pos_x = 0
@@ -225,10 +225,8 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
             if sec_transf.rotation.x or sec_transf.rotation.y or sec_transf.rotation.z:
 
                 log.warning(
-                    'Sections "'
-                    + sec_uid
-                    + '" is rotated, it is \
-                            not possible to take that into acount in SUMO !'
+                    f"Sections '{sec_uid}' is rotated, it is"
+                    "not possible to take that into account in SUMO !"
                 )
 
             # Elements
@@ -252,11 +250,8 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
 
                 if elem_transf.rotation.x or elem_transf.rotation.y or elem_transf.rotation.z:
                     log.warning(
-                        'Element "'
-                        + elem_uid
-                        + '" is rotated, it \
-                                 is not possible to take that into acount in \
-                                 SUMO !'
+                        f"Element '{elem_uid}' is rotated, it is"
+                        "not possible to take that into account in SUMO !"
                     )
 
                 # Fuselage profiles
@@ -467,7 +462,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
         # Positionings
         if tixi.checkElement(wing_xpath + "/positionings"):
             pos_cnt = tixi.getNamedChildrenCount(wing_xpath + "/positionings", "positioning")
-            log.info(str(wing_cnt) + ' "positionning" has been found : ')
+            log.info(str(wing_cnt) + ' "positioning" has been found : ')
 
             pos_x_list = []
             pos_y_list = []
@@ -484,12 +479,12 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
                 dihedral_deg = tixi.getDoubleElement(pos_xpath + "/dihedralAngle")
                 dihedral = math.radians(dihedral_deg)
 
-                # Get the corresponding translation of each positionning
+                # Get the corresponding translation of each positioning
                 pos_x_list.append(length * math.sin(sweep))
                 pos_y_list.append(length * math.cos(dihedral) * math.cos(sweep))
                 pos_z_list.append(length * math.sin(dihedral) * math.cos(sweep))
 
-                # Get which section are connected by the positionning
+                # Get which section are connected by the positioning
                 if tixi.checkElement(pos_xpath + "/fromSectionUID"):
                     from_sec = tixi.getTextElement(pos_xpath + "/fromSectionUID")
                 else:
@@ -502,7 +497,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
                     to_sec = ""
                 to_sec_list.append(to_sec)
 
-            # Re-loop though the positionning to re-order them
+            # Re-loop though the positioning to re-order them
             for j_pos in range(pos_cnt):
                 if from_sec_list[j_pos] == "":
                     prev_pos_x = 0
@@ -547,11 +542,8 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
 
             if elem_cnt > 1:
                 log.warning(
-                    "Sections "
-                    + sec_uid
-                    + "  contains multiple \
-                             element, it could be an issue for the conversion \
-                             to SUMO!"
+                    f"Sections {sec_uid} contains multiple element,"
+                    " it could be an issue for the conversion to SUMO!"
                 )
 
             for i_elem in range(elem_cnt):
@@ -630,7 +622,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
                 # Convert point list into string
                 prof_str = ""
 
-                # Airfoil points order : shoud be from TE (1 0) to LE (0 0)
+                # Airfoil points order : should be from TE (1 0) to LE (0 0)
                 # then TE(1 0), but not reverse way.
 
                 # to avoid double zero, not accepted by SUMO
@@ -666,10 +658,9 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
         # Add Wing caps
         add_wing_cap(sumo, wg_sk_xpath)
 
-    # Engyine pylon(s) ---------------------------------------------------------
+    # Engine pylon(s) ---------------------------------------------------------
 
-    inc_pylon_xpath = "/cpacs/toolspecific/CEASIOMpy/engine/includePylon"
-    include_pylon = get_value_or_default(tixi, inc_pylon_xpath, False)
+    include_pylon = get_value_or_default(tixi, SUMO_INCLUDE_PYLON_XPATH, False)
 
     if tixi.checkElement(PYLONS_XPATH) and include_pylon:
         pylon_cnt = tixi.getNamedChildrenCount(PYLONS_XPATH, "enginePylon")
@@ -719,7 +710,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
         # Positionings
         if tixi.checkElement(pylon_xpath + "/positionings"):
             pos_cnt = tixi.getNamedChildrenCount(pylon_xpath + "/positionings", "positioning")
-            log.info(str(pylon_cnt) + ' "positionning" has been found : ')
+            log.info(str(pylon_cnt) + ' "positioning" has been found : ')
 
             pos_x_list = []
             pos_y_list = []
@@ -736,12 +727,12 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
                 dihedral_deg = tixi.getDoubleElement(pos_xpath + "/dihedralAngle")
                 dihedral = math.radians(dihedral_deg)
 
-                # Get the corresponding translation of each positionning
+                # Get the corresponding translation of each positioning
                 pos_x_list.append(length * math.sin(sweep))
                 pos_y_list.append(length * math.cos(dihedral) * math.cos(sweep))
                 pos_z_list.append(length * math.sin(dihedral) * math.cos(sweep))
 
-                # Get which section are connected by the positionning
+                # Get which section are connected by the positioning
                 if tixi.checkElement(pos_xpath + "/fromSectionUID"):
                     from_sec = tixi.getTextElement(pos_xpath + "/fromSectionUID")
                 else:
@@ -754,7 +745,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
                     to_sec = ""
                 to_sec_list.append(to_sec)
 
-            # Re-loop though the positionning to re-order them
+            # Re-loop though the positioning to re-order them
             for j_pos in range(pos_cnt):
                 if from_sec_list[j_pos] == "":
                     prev_pos_x = 0
@@ -872,7 +863,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
 
                 check_reversed_wing.append(wg_sec_center_y)
 
-                # Add roation from element and sections
+                # Add rotation from element and sections
                 # Adding the two angles: Maybe not work in every case!!!
                 add_rotation = SimpleNamespace()
                 add_rotation.x = elem_transf.rotation.x + sec_transf.rotation.x
@@ -939,8 +930,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
 
     # Engine(s) ----------------------------------------------------------------
 
-    inc_engine_xpath = "/cpacs/toolspecific/CEASIOMpy/engine/includeEngine"
-    include_engine = get_value_or_default(tixi, inc_engine_xpath, False)
+    include_engine = get_value_or_default(tixi, SUMO_INCLUDE_ENGINE_XPATH, False)
 
     if tixi.checkElement(ENGINES_XPATH) and include_engine:
         engine_cnt = tixi.getNamedChildrenCount(ENGINES_XPATH, "engine")

--- a/ceasiompy/CPACS2SUMO/cpacs2sumo.py
+++ b/ceasiompy/CPACS2SUMO/cpacs2sumo.py
@@ -91,7 +91,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
 
     EMPTY_SMX = Path(MODULE_DIR, "files", "sumo_empty.smx")
 
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
     sumo = open_tixi(str(EMPTY_SMX))
 
     # Fuslage(s) ---------------------------------------------------------------

--- a/ceasiompy/CPACS2SUMO/cpacs2sumo.py
+++ b/ceasiompy/CPACS2SUMO/cpacs2sumo.py
@@ -92,7 +92,7 @@ def convert_cpacs_to_sumo(cpacs_path, cpacs_out_path):
     EMPTY_SMX = Path(MODULE_DIR, "files", "sumo_empty.smx")
 
     tixi = open_tixi(cpacs_path)
-    sumo = open_tixi(str(EMPTY_SMX))
+    sumo = open_tixi(EMPTY_SMX)
 
     # Fuslage(s) ---------------------------------------------------------------
 

--- a/ceasiompy/CPACSUpdater/cpacsupdater.py
+++ b/ceasiompy/CPACSUpdater/cpacsupdater.py
@@ -46,8 +46,8 @@ def update_cpacs_file(cpacs_path, cpacs_out_path, optim_var_dict):
         * See CPACSCreator api function,
 
     Args:
-        cpacs_path (str): Path to CPACS file to update
-        cpacs_out_path (str):Path to the updated CPACS file
+        cpacs_path (Path): Path to CPACS file to update
+        cpacs_out_path (Path):Path to the updated CPACS file
         optim_var_dict (dict): Dictionary containing all the variable
                                value/min/max and command to modify a CPACS file
 

--- a/ceasiompy/CPACSUpdater/cpacsupdater.py
+++ b/ceasiompy/CPACSUpdater/cpacsupdater.py
@@ -56,7 +56,7 @@ def update_cpacs_file(cpacs_path, cpacs_out_path, optim_var_dict):
     log.info("----- Start of CPACSUpdater -----")
     log.info(f"{cpacs_path} will be updated.")
 
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
     tigl = open_tigl(tixi)
 
     # Object seems to be unused, but are use in "eval" function

--- a/ceasiompy/ExportCSV/exportcsv.py
+++ b/ceasiompy/ExportCSV/exportcsv.py
@@ -52,7 +52,7 @@ MODULE_NAME = MODULE_DIR.name
 
 def export_aeromaps(cpacs_path, cpacs_out_path):
 
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
 
     aeromap_to_export_xpath = CEASIOMPY_XPATH + "/export/aeroMapToExport"
 
@@ -69,7 +69,7 @@ def export_aeromaps(cpacs_path, cpacs_out_path):
 
         log.info(f"Aeromap(s) has been saved to {csv_path}")
 
-    cpacs.save_cpacs(str(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path, overwrite=True)
 
 
 # =================================================================================================

--- a/ceasiompy/ExportCSV/tests/test_exportcsv.py
+++ b/ceasiompy/ExportCSV/tests/test_exportcsv.py
@@ -50,7 +50,7 @@ def change_test_dir(request, monkeypatch):
 def test_export_aeromaps():
     """Test function 'exportcsv' function."""
 
-    export_aeromaps(str(CPACS_IN_PATH), str(CPACS_IN_PATH))
+    export_aeromaps(CPACS_IN_PATH, CPACS_IN_PATH)
 
     # Read and check csv file
     with open(CSV_FILE_PATH, "r") as csv_file:

--- a/ceasiompy/ModuleTemplate/moduletemplate.py
+++ b/ceasiompy/ModuleTemplate/moduletemplate.py
@@ -151,7 +151,7 @@ def get_fuselage_scaling(cpacs_path, cpacs_out_path):
     """
 
     # Open TIXI handle
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
 
     # Create xpaths
     SCALING_XPATH = "/fuselage/transformation/scaling"

--- a/ceasiompy/ModuleTemplate/tests/test_moduletemplate.py
+++ b/ceasiompy/ModuleTemplate/tests/test_moduletemplate.py
@@ -66,7 +66,7 @@ def test_sum_funcion():
 def test_get_fuselage_scaling():
     """Test function 'get_fuselage_scaling'"""
 
-    x, y, z = get_fuselage_scaling(str(CPACS_IN_PATH), str(CPACS_OUT_PATH))
+    x, y, z = get_fuselage_scaling(CPACS_IN_PATH, CPACS_OUT_PATH)
 
     assert x == approx(1)
     assert y == approx(0.5)

--- a/ceasiompy/Optimisation/optimisation.py
+++ b/ceasiompy/Optimisation/optimisation.py
@@ -88,8 +88,8 @@ class Geom_param(om.ExplicitComponent):
         if Rt.counter == 0:
 
             # For the first iteration, update the CPACS file from previous module
-            cpacs_in = str(Rt.modules[0].cpacs_in)
-            cpacs_out = str(Rt.modules[0].cpacs_out)
+            cpacs_in = Rt.modules[0].cpacs_in
+            cpacs_out = Rt.modules[0].cpacs_out
             update_cpacs_file(cpacs_in, cpacs_out, Rt.geom_dict)
 
         else:
@@ -108,8 +108,8 @@ class Geom_param(om.ExplicitComponent):
                     Rt.modules[m].cpacs_in = Rt.modules[-1].cpacs_out
 
                     # Update the geometry of the CPACS file
-                    cpacs_in = str(Rt.modules[m].cpacs_in)
-                    cpacs_out = str(Rt.modules[m].cpacs_out)
+                    cpacs_in = Rt.modules[m].cpacs_in
+                    cpacs_out = Rt.modules[m].cpacs_out
                     update_cpacs_file(cpacs_in, cpacs_out, Rt.geom_dict)
 
                     # # The first module of the loop must update its output where the input
@@ -191,8 +191,7 @@ class ModuleComp(om.ExplicitComponent):
         module = [m for m in Rt.modules if m.name == self.module_name][0]
 
         # Updating inputs in CPACS file
-        cpacs_path = str(module.cpacs_in)
-        tixi = open_tixi(cpacs_path)
+        tixi = open_tixi(module.cpacs_in)
         for name in inputs:
             if name in Rt.optim_var_dict:
                 xpath = Rt.optim_var_dict[name][4]
@@ -205,13 +204,13 @@ class ModuleComp(om.ExplicitComponent):
                     tixi.updateFloatVector(xpath, v, size, "%g")
                 else:
                     add_float_vector(tixi, xpath, inputs[name])
-        tixi.save(cpacs_path)
+        tixi.save(module.cpacs_in)
 
         # Running the module
         run_module(module, Rt.wkflow_dir, Rt.counter)
 
         # Feeding CPACS file results to outputs
-        tixi = open_tixi(str(module.cpacs_out))
+        tixi = open_tixi(module.cpacs_out)
         for name in outputs:
             if name in Rt.optim_var_dict:
                 xpath = Rt.optim_var_dict[name][4]
@@ -240,7 +239,7 @@ class SmComp(om.ExplicitComponent):
         module = [m for m in Rt.modules if m.name == self.module_name][0]
 
         # Take CPACS file from the optimisation
-        cpacs_path = str(module.cpacs_in)
+        cpacs_path = module.cpacs_in
         tixi = open_tixi(cpacs_path)
         self.Model = load_surrogate(tixi)
         tixi.save(cpacs_path)
@@ -271,7 +270,7 @@ class SmComp(om.ExplicitComponent):
         module = [m for m in Rt.modules if m.name == self.module_name][0]
 
         # Write the inouts to the CPACS
-        tixi = open_tixi(str(module.cpacs_in))
+        tixi = open_tixi(module.cpacs_in)
         write_inouts(self.xd, xp, tixi)
         write_inouts(self.yd, yp, tixi)
         tixi.save(str(module.cpacs_out))
@@ -531,7 +530,7 @@ def routine_launcher(optim_method, module_optim, wkflow_dir):
     Rt.wkflow_dir = wkflow_dir
 
     # Cpacs from the ouput of the last module
-    cpacs_path = str(Rt.modules[0].cpacs_in)
+    cpacs_path = Rt.modules[0].cpacs_in
 
     cpacs = CPACS(cpacs_path)
 

--- a/ceasiompy/Optimisation/optimisation.py
+++ b/ceasiompy/Optimisation/optimisation.py
@@ -295,7 +295,7 @@ class Objective(om.ExplicitComponent):
         """Compute the objective expression"""
 
         # Add new variables to dictionnary
-        cpacs = CPACS(str(Rt.modules[-1].cpacs_out))
+        cpacs = CPACS(Rt.modules[-1].cpacs_out)
 
         update_dict(cpacs.tixi, Rt.optim_var_dict)
 

--- a/ceasiompy/PlotAeroCoefficients/plotaerocoef.py
+++ b/ceasiompy/PlotAeroCoefficients/plotaerocoef.py
@@ -201,7 +201,7 @@ def plot_aero_coef(cpacs_path, cpacs_out_path):
     """
 
     # Open TIXI handle
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
 
     # Get aeroMap list to plot
     aeromap_to_plot_xpath = PLOT_XPATH + "/aeroMapToPlot"
@@ -248,7 +248,7 @@ def plot_aero_coef(cpacs_path, cpacs_out_path):
     mach_crit = get_value_or_default(cpacs.tixi, crit_xpath + "/mach", "None")
     aos_crit = get_value_or_default(cpacs.tixi, crit_xpath + "/aos", "None")
 
-    cpacs.save_cpacs(str(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path, overwrite=True)
 
     # Modify criterion and title according to user option
     if len(aeromap["altitude"].unique()) == 1:

--- a/ceasiompy/PyTornado/runpytornado.py
+++ b/ceasiompy/PyTornado/runpytornado.py
@@ -334,7 +334,7 @@ def main(cpacs_in_path, cpacs_out_path):
     )
 
     # ===== Extract load =====
-    tixi = open_tixi(str(cpacs_in_path))
+    tixi = open_tixi(cpacs_in_path)
     extract_loads_xpath = "/cpacs/toolspecific/pytornado/save_results/extractLoads"
     extract_loads = get_value_or_default(tixi, extract_loads_xpath, False)
 

--- a/ceasiompy/SU2Run/func/su2config.py
+++ b/ceasiompy/SU2Run/func/su2config.py
@@ -275,7 +275,7 @@ def generate_su2_cfd_config(cpacs_path, cpacs_out_path, wkdir):
                 config_output_path = Path(wkdir, config_dir_path, CONFIG_CFD_NAME)
                 cfg.write_file(config_output_path, overwrite=True)
 
-    cpacs.save_cpacs(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path, overwrite=True)
 
 
 # =================================================================================================

--- a/ceasiompy/SU2Run/func/su2config.py
+++ b/ceasiompy/SU2Run/func/su2config.py
@@ -82,7 +82,7 @@ def generate_su2_cfd_config(cpacs_path, cpacs_out_path, wkdir):
 
     """
 
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
 
     # Get the SU2 Mesh
     su2_mesh_path = Path(get_value(cpacs.tixi, SU2MESH_XPATH))
@@ -153,7 +153,7 @@ def generate_su2_cfd_config(cpacs_path, cpacs_out_path, wkdir):
 
     # General parmeters
     cfg["RESTART_SOL"] = "NO"
-    cfg["REF_LENGTH"] = cpacs.aircraft.ref_lenght
+    cfg["REF_LENGTH"] = cpacs.aircraft.ref_length
     cfg["REF_AREA"] = cpacs.aircraft.ref_area
     cfg["REF_ORIGIN_MOMENT_X"] = cpacs.aircraft.ref_point_x
     cfg["REF_ORIGIN_MOMENT_Y"] = cpacs.aircraft.ref_point_y
@@ -275,7 +275,7 @@ def generate_su2_cfd_config(cpacs_path, cpacs_out_path, wkdir):
                 config_output_path = Path(wkdir, config_dir_path, CONFIG_CFD_NAME)
                 cfg.write_file(config_output_path, overwrite=True)
 
-    cpacs.save_cpacs(str(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path), overwrite=True)
 
 
 # =================================================================================================

--- a/ceasiompy/SU2Run/func/su2results.py
+++ b/ceasiompy/SU2Run/func/su2results.py
@@ -202,7 +202,7 @@ def get_su2_results(cpacs_path, cpacs_out_path, wkdir):
             extract_loads(config_dir)
 
     aeromap.save()
-    cpacs.save_cpacs(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path, overwrite=True)
 
 
 # =================================================================================================

--- a/ceasiompy/SU2Run/func/su2results.py
+++ b/ceasiompy/SU2Run/func/su2results.py
@@ -70,7 +70,7 @@ def get_su2_results(cpacs_path, cpacs_out_path, wkdir):
 
     """
 
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
 
     if not wkdir.exists():
         raise OSError(f"The working directory : {wkdir} does not exit!")
@@ -128,7 +128,7 @@ def get_su2_results(cpacs_path, cpacs_out_path, wkdir):
 
         # Damping derivatives
         rotation_rate = get_value_or_default(cpacs.tixi, SU2_ROTATION_RATE_XPATH, -1.0)
-        ref_len = cpacs.aircraft.ref_lenght
+        ref_len = cpacs.aircraft.ref_length
         adim_rot_rate = rotation_rate * ref_len / velocity
 
         coefs = {"cl": cl, "cd": cd, "cs": cs, "cmd": cmd, "cms": cms, "cml": cml}
@@ -202,7 +202,7 @@ def get_su2_results(cpacs_path, cpacs_out_path, wkdir):
             extract_loads(config_dir)
 
     aeromap.save()
-    cpacs.save_cpacs(str(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path), overwrite=True)
 
 
 # =================================================================================================

--- a/ceasiompy/SU2Run/su2run.py
+++ b/ceasiompy/SU2Run/su2run.py
@@ -158,7 +158,7 @@ def main(cpacs_path, cpacs_out_path):
 
     log.info("----- Start of " + MODULE_NAME + " -----")
 
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
 
     # Get number of proc to use from the CPACS file
     nb_proc = get_value_or_default(tixi, SU2_NB_CPU_XPATH, get_reasonable_nb_cpu())

--- a/ceasiompy/SUMOAutoMesh/sumoautomesh.py
+++ b/ceasiompy/SUMOAutoMesh/sumoautomesh.py
@@ -75,7 +75,7 @@ def add_mesh_parameters(sumo_file_path, refine_level=0.0):
     log.info("Refinement factor is {}".format(refine_factor))
 
     # Open SUMO (.smx) with tixi library
-    sumo = open_tixi(str(sumo_file_path))
+    sumo = open_tixi(sumo_file_path)
     ROOT_XPATH = "/Assembly"
 
     # Get all Body (fuselage) and apply mesh parameters

--- a/ceasiompy/SUMOAutoMesh/sumoautomesh.py
+++ b/ceasiompy/SUMOAutoMesh/sumoautomesh.py
@@ -219,7 +219,7 @@ def create_SU2_mesh(cpacs_path, cpacs_out_path):
 
     """
 
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
 
     sumo_results_dir = get_results_directory("SUMOAutoMesh")
     su2_mesh_path = Path(sumo_results_dir, "ToolOutput.su2")

--- a/ceasiompy/SkinFriction/skinfriction.py
+++ b/ceasiompy/SkinFriction/skinfriction.py
@@ -138,7 +138,7 @@ def add_skin_friction(cpacs_path, cpacs_out_path):
     """
 
     # Load a CPACS file
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
 
     analyses_xpath = "/cpacs/toolspecific/CEASIOMpy/geometry/analysis"
 
@@ -233,7 +233,7 @@ def add_skin_friction(cpacs_path, cpacs_out_path):
 
     log.info('AeroMap "' + aeromap_uid + '" has been added to the CPACS file')
 
-    cpacs.save_cpacs(str(cpacs_out_path), overwrite=True)
+    cpacs.save_cpacs(cpacs_out_path, overwrite=True)
 
 
 def main(cpacs_path, cpacs_out_path):

--- a/ceasiompy/SkinFriction/tests/test_skinfriction.py
+++ b/ceasiompy/SkinFriction/tests/test_skinfriction.py
@@ -75,10 +75,10 @@ def test_add_skin_friction():
     """Test function 'add_skin_friction'"""
 
     # User the function to add skin frictions
-    add_skin_friction(str(CPACS_IN_PATH), str(CPACS_OUT_PATH))
+    add_skin_friction(CPACS_IN_PATH, CPACS_OUT_PATH)
 
     # Read the aeromap with the skin friction added in the output cpacs file
-    cpacs = CPACS(str(CPACS_OUT_PATH))
+    cpacs = CPACS(CPACS_OUT_PATH)
     apm_sf = cpacs.get_aeromap_by_uid("test_apm_SkinFriction")
 
     # Expected values

--- a/ceasiompy/StabilityDynamic/dynamicstabilityState.py
+++ b/ceasiompy/StabilityDynamic/dynamicstabilityState.py
@@ -173,7 +173,7 @@ def dynamic_stability_analysis(cpacs_path, cpacs_out_path):
 
     s = cpacs.aircraft.ref_area  # Wing area : s  for non-dimonsionalisation of aero data.
     mac = (
-        cpacs.aircraft.ref_lenght
+        cpacs.aircraft.ref_length
     )  # ref length for non dimensionalisation, Mean aerodynamic chord: mac,
 
     # TODO: check that

--- a/ceasiompy/StabilityDynamic/dynamicstabilityState.py
+++ b/ceasiompy/StabilityDynamic/dynamicstabilityState.py
@@ -82,12 +82,12 @@ def dynamic_stability_analysis(cpacs_path, cpacs_out_path):
     """Function to analyse a full Aeromap
 
     Function 'dynamic_stability_analysis' analyses longitudinal dynamic
-    stability and directionnal dynamic.
+    stability and directional dynamic.
 
     Args:
         cpacs_path (str): Path to CPACS file
         cpacs_out_path (str):Path to CPACS output file
-        plot (boolean): Choise to plot graph or not
+        plot (boolean): Choice to plot graph or not
 
     Returns:  (#TODO put that in the documentation)
         *   Adrvertisements certifying if the aircraft is stable or Not
@@ -95,7 +95,7 @@ def dynamic_stability_analysis(cpacs_path, cpacs_out_path):
                 -	Plot cms VS aoa for constant Alt, Mach and different aos
                 -	Plot cms VS aoa for const alt and aos and different mach
                 -	plot cms VS aoa for constant mach, AOS and different altitudes
-        *  In case of directionnal dynamic UNstability or unvalid test on data:
+        *  In case of directional dynamic UNstability or unvalid test on data:
                 -	Pcot cml VS aos for constant Alt, Mach and different aoa
                 -	Plot cml VS aos for const alt and aoa and different mach
                 -	plot cml VS aos for constant mach, AOA and different altitudes

--- a/ceasiompy/StabilityStatic/staticstability.py
+++ b/ceasiompy/StabilityStatic/staticstability.py
@@ -90,7 +90,7 @@ def static_stability_analysis(cpacs_path, cpacs_out_path):
                 -   If there one aos value which is repeated for a given altitude, mach, aoa
     """
 
-    cpacs = CPACS(str(cpacs_path))
+    cpacs = CPACS(cpacs_path)
 
     # TODO: add as CPACS option
     plot_for_different_mach = False  # To check Mach influence

--- a/ceasiompy/StabilityStatic/tests/test_stabilitystatic.py
+++ b/ceasiompy/StabilityStatic/tests/test_stabilitystatic.py
@@ -153,7 +153,7 @@ def test_static_stability_analysis():
     # Make the static stability analysis, on the modified xml file
     static_stability_analysis(cpacs_path, cpacs_out_path)
 
-    tixi = open_tixi(str(cpacs_out_path))
+    tixi = open_tixi(cpacs_out_path)
     static_xpath = "/cpacs/toolspecific/CEASIOMpy/stability/static"
     long_static_stable = get_value(tixi, static_xpath + "/results/longitudinalStaticStable")
     lat_static_stable = get_value(tixi, static_xpath + "/results/lateralStaticStable")

--- a/ceasiompy/StabilityStatic/tests/test_stabilitystatic.py
+++ b/ceasiompy/StabilityStatic/tests/test_stabilitystatic.py
@@ -141,7 +141,7 @@ def test_static_stability_analysis():
     cpacs_path = Path(MODULE_DIR, "ToolInput", "CPACSTestStability.xml")
     cpacs_out_path = Path(MODULE_DIR, "ToolOutput", "CPACSTestStability.xml")
 
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
 
     # Get Aeromap UID list
 

--- a/ceasiompy/utils/ceasiompyutils.py
+++ b/ceasiompy/utils/ceasiompyutils.py
@@ -243,7 +243,7 @@ def get_part_type(cpacs_path: Path, part_uid: str) -> str:
 
     """
 
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
 
     # split uid if mirrored part
     part_uid = part_uid.split("_mirrored")[0]

--- a/ceasiompy/utils/ceasiompyutils.py
+++ b/ceasiompy/utils/ceasiompyutils.py
@@ -219,7 +219,7 @@ def aircraft_name(tixi_or_cpacs):
     # *modify corresponding test
 
     if isinstance(tixi_or_cpacs, Path):
-        tixi = open_tixi(str(tixi_or_cpacs))
+        tixi = open_tixi(tixi_or_cpacs)
     else:
         tixi = tixi_or_cpacs
 

--- a/ceasiompy/utils/commonxpath.py
+++ b/ceasiompy/utils/commonxpath.py
@@ -78,6 +78,10 @@ WKDIR_XPATH = "/cpacs/toolspecific/CEASIOMpy/filesPath/wkdirPath"
 # GMSH
 
 
+# SUMO
+SUMO_INCLUDE_PYLON_XPATH = "/cpacs/toolspecific/CEASIOMpy/engine/includePylon"
+SUMO_INCLUDE_ENGINE_XPATH = "/cpacs/toolspecific/CEASIOMpy/engine/includeEngine"
+
 # SU2
 SU2_XPATH = "/cpacs/toolspecific/CEASIOMpy/aerodynamics/su2"
 SU2_AEROMAP_UID_XPATH = SU2_XPATH + "/aeroMapUID"

--- a/ceasiompy/utils/moduleinterfaces.py
+++ b/ceasiompy/utils/moduleinterfaces.py
@@ -202,7 +202,7 @@ def check_cpacs_input_requirements(
         specs_module = get_specs_for_module(submod_name, raise_error=True)
         cpacs_inout = specs_module.cpacs_inout
 
-    tixi = open_tixi(str(cpacs_file))
+    tixi = open_tixi(cpacs_file)
     missing_nodes = []
     for entry in cpacs_inout.inputs:
 
@@ -353,8 +353,8 @@ def create_default_toolspecific():
 
     EMPTY_CPACS_PATH = Path(MODULE_DIR, "doc", "empty_cpacs.xml")
 
-    tixi_in = open_tixi(str(EMPTY_CPACS_PATH))
-    tixi_out = open_tixi(str(EMPTY_CPACS_PATH))
+    tixi_in = open_tixi(EMPTY_CPACS_PATH)
+    tixi_out = open_tixi(EMPTY_CPACS_PATH)
 
     for _, specs in get_all_module_specs().items():
         if specs is not None:

--- a/ceasiompy/utils/moduleinterfaces.py
+++ b/ceasiompy/utils/moduleinterfaces.py
@@ -417,7 +417,7 @@ def check_workflow(cpacs_path, submodule_list):
     if not isinstance(submodule_list, (list, tuple)):
         raise TypeError("'submodule_list' must be of type list or tuple")
 
-    tixi = open_tixi(str(cpacs_path))
+    tixi = open_tixi(cpacs_path)
     xpaths_from_workflow = set()
     err_msg = False
     for submod_name in submodule_list:

--- a/ceasiompy/utils/tests/tests_ceasiompyutils/test_ceasiompyutils.py
+++ b/ceasiompy/utils/tests/tests_ceasiompyutils/test_ceasiompyutils.py
@@ -117,7 +117,7 @@ def test_aircraft_name():
     assert aircraft_name(cpacs_in) == "D150"
 
     # Get name form TIXI handle
-    tixi = open_tixi(str(cpacs_in))
+    tixi = open_tixi(cpacs_in)
     assert aircraft_name(tixi) == "D150"
 
 

--- a/ceasiompy/utils/tests/tests_gereralclasses/test_generalclasses.py
+++ b/ceasiompy/utils/tests/tests_gereralclasses/test_generalclasses.py
@@ -59,7 +59,7 @@ def test_SimpleNamespace():
 def test_Point():
     """Test the class 'Point'"""
 
-    cpacs = CPACS(str(CPACS_PATH))
+    cpacs = CPACS(CPACS_PATH)
     tixi = cpacs.tixi
 
     point1 = Point()
@@ -76,10 +76,10 @@ def test_Point():
     assert point1.z == 0.5
 
 
-def test_Transfomation():
+def test_Transformation():
     """Test the class 'Point'"""
 
-    cpacs = CPACS(str(CPACS_PATH))
+    cpacs = CPACS(CPACS_PATH)
     tixi = cpacs.tixi
 
     trans1 = Transformation()

--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,7 @@ dependencies:
 
   - pip:
     - smt==0.7.1
-    - cpacspy==0.0.10
+    - cpacspy==0.0.11
     - gmsh >= 4.10.1
     #- aeroframe  # See: https://github.com/airinnova/aeroframe
     #- framat  # See: https://github.com/airinnova/framat

--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,7 @@ dependencies:
 
   - pip:
     - smt==0.7.1
-    - cpacspy==0.0.8
+    - cpacspy==0.0.10
     - gmsh >= 4.10.1
     #- aeroframe  # See: https://github.com/airinnova/aeroframe
     #- framat  # See: https://github.com/airinnova/framat


### PR DESCRIPTION
With cpacspy version 0.0.11, it is now possible to use Path object open cpacs file and the typo of "ref_lenght" has been fixed.