### PR TITLE
Guard deprecated concat copy keyword by pandas version in smtrain.py

### DIFF
--- a/src/ceasiompy/smtrain/smtrain.py
+++ b/src/ceasiompy/smtrain/smtrain.py
@@ -16,6 +16,9 @@ TODO:
 # Imports
 import pandas as pd
 
+from packaging.version import Version
+
+PANDAS_VERSION = Version(pd.__version__)
 from ceasiompy.utils.progress import progress_update
 from ceasiompy.utils.ceasiompyutils import call_main
 from ceasiompy.smtrain.func.utils import (
@@ -328,7 +331,11 @@ def _geometry_exploration(
 
     # Save Best Geometry from training in adequate Results Directory
     training_results_df = (
-        pd.concat([level1_df, level2_df], ignore_index=True, copy=False)
+        (
+            pd.concat([level1_df, level2_df], ignore_index=True, copy=False)
+            if PANDAS_VERSION < Version("3.0")
+            else pd.concat([level1_df, level2_df], ignore_index=True)
+        )
         if "level2_df" in locals() and level2_df is not None
         else level1_df
     )


### PR DESCRIPTION
Fixes #375

## Changes

Guard the deprecated `copy` keyword of `pd.concat` by pandas version in
`src/ceasiompy/smtrain/smtrain.py`, so behaviour is preserved on every
supported version:

- `src/ceasiompy/smtrain/smtrain.py`: module-level
  `PANDAS_VERSION = Version(pd.__version__)` (from `packaging`, already a
  transitive dependency of pandas), and in the `training_results_df`
  expression:

  ```python
  (
      (
          pd.concat([level1_df, level2_df], ignore_index=True, copy=False)
          if PANDAS_VERSION < Version("3.0")
          else pd.concat([level1_df, level2_df], ignore_index=True)
      )
      if "level2_df" in locals() and level2_df is not None
      else level1_df
  )
  ```

  — the same pattern as NVIDIA/cuml#8142.

## Verification

The `copy` keyword never affects the **result** of `concat` on any
pandas version, only whether input buffers are copied; the branch keeps
that behaviour exactly as it was on each side of the boundary. Runtime
checks in isolated venvs:

- pandas 2.3.3 takes the `copy=False` branch: identical results to
  today's code (`ignore_index=True` row append), no warning.
- pandas 3.0.5 takes the plain branch: no `Pandas4Warning` is emitted,
  results identical (the `copy` keyword is a documented no-op under
  Copy-on-Write).
- Modified file passes `python -m py_compile`.
